### PR TITLE
Deal with Next13->14 change

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -77,8 +77,6 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
       - name: Build sitemap with next-sitemap
         run: ${{ steps.detect-package-manager.outputs.runner }} next-sitemap
-      - name: Static HTML export with Next.js
-        run: ${{ steps.detect-package-manager.outputs.runner }} next export
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: "export",
   reactStrictMode: true,
   // images: {
   //   loader: 'imgix',

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "postbuild": "next-sitemap",
     "start": "next start",
     "lint": "next lint",
-    "export": "next export",
     "format": "prettier --write src components"
   },
   "dependencies": {


### PR DESCRIPTION
From Next@14, next export has been removed in favor of "output": "export" in next.config.js.

To deal with the next.js update in https://github.com/iGEMKyotoOfficial/iGEMKyotoOfficial.github.io/pull/1 , changed package.json setting, next.config.js, and nextjs.yml (workflow file)

Ref: 
[Next.js Documentation](https://nextjs.org/docs/app/building-your-application/deploying/static-exports "Next.js documentation")
[StackOverflow article](https://stackoverflow.com/questions/77631875/while-deploying-nextjs-app-throwing-error-the-next-export-command-has-been-re "stackoverflow")